### PR TITLE
Add starting valves for hardmode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.1.3
+Date: ????
+  Features:
+    - Added valves to the starting inventory when playing with pyhardmode and either valves or configurable valves
+---------------------------------------------------------------------------------------------------
 Version: 3.1.2
 Date: 2024-12-15
   Features:

--- a/control.lua
+++ b/control.lua
@@ -15,6 +15,15 @@ script.on_init(function(event)
     created_items["stone-furnace"] = 1
     created_items["py-sinkhole"] = 2
     created_items["multiblade-turbine-mk01"] = 1
+    if script.active_mods["pyhardmode"] then
+        if script.active_mods["configurable-valves"] then
+            created_items["configurable-valve"] = 6
+        end
+        if script.active_mods["valves"] then
+                created_items["valves-overflow"] = 3
+                created_items["valves-top_up"] = 3
+        end
+    end
     remote.call('freeplay', 'set_created_items', created_items)
   end
 end)


### PR DESCRIPTION
Improve compatibility with pyhardmode by also adding starting valves when using pyblock+pyhardmode + one of two valve mods.

test with pyblock+HM+valves:
![image](https://github.com/user-attachments/assets/3d01e129-ab30-4380-a1fb-ec08e4253b98)

context: https://discord.com/channels/560199483065892894/731457957895602247/1319350347428532344
